### PR TITLE
Make app async, update docs for concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# JMeter Practice API
+
+This FastAPI application exposes simple CRUD endpoints that are convenient for load-testing with tools such as JMeter. It is ready for production-style deployments and can handle high concurrency when run with multiple workers.
+
+## Setup
+
+Install the dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running
+
+Launch the app with Uvicorn. Use the `--workers` option to allow several processes to serve requests concurrently. The following example starts four workers, which is generally sufficient for around 100 concurrent requests during JMeter practice:
+
+```bash
+uvicorn main:app --host 0.0.0.0 --port 8000 --workers 4
+```
+
+## Available Endpoints
+
+- `POST /login` – dummy authentication returning a token
+- `GET /items` – list all items
+- `POST /items` – create an item
+- `GET /items/{item_id}` – retrieve one item
+- `PUT /items/{item_id}` – update an item
+- `DELETE /items/{item_id}` – delete an item
+- `POST /upload` – upload a file and get its size
+- `GET /slow` – simulate a slow request using the `delay` parameter
+
+A root endpoint `/` is also provided to verify the server is running.
+

--- a/Readme.md
+++ b/Readme.md
@@ -1,3 +1,0 @@
-```bash
-  uvicorn main:app --reload
-```

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI, HTTPException, UploadFile, File, Form
 from fastapi.middleware.cors import CORSMiddleware
-from time import sleep
+import asyncio
 
 from models import Item, UserCredentials, ItemCreate
 import storage
@@ -16,49 +16,53 @@ app.add_middleware(
 )
 
 @app.post("/login")
-def login(creds: UserCredentials):
+async def login(creds: UserCredentials):
     # dummy auth: accept any username/password
     return {"token": f"dummy-token-for-{creds.username}"}
 
 @app.get("/items")
-def read_items():
+async def read_items():
     return storage.list_items()
 
 @app.post("/items", status_code=201, response_model=Item)
-def create_item(item: ItemCreate):
+async def create_item(item: ItemCreate):
     try:
         return storage.create_item(item)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
 @app.get("/items/{item_id}")
-def read_item(item_id: int):
+async def read_item(item_id: int):
     item = storage.get_item(item_id)
     if not item:
         raise HTTPException(status_code=404, detail="Item not found")
     return item
 
 @app.put("/items/{item_id}")
-def update_item(item_id: int, item: Item):
+async def update_item(item_id: int, item: Item):
     updated = storage.update_item(item_id, item)
     if not updated:
         raise HTTPException(status_code=404, detail="Item not found")
     return updated
 
 @app.delete("/items/{item_id}", status_code=204)
-def delete_item(item_id: int):
+async def delete_item(item_id: int):
     deleted = storage.delete_item(item_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Item not found")
 
 @app.post("/upload")
 async def upload_file(file: UploadFile = File(...)):
-    # just read it, return size
+    """Upload a file and return its size."""
     content = await file.read()
     return {"filename": file.filename, "size": len(content)}
 
 @app.get("/slow")
-def slow_endpoint(delay: int = 2):
-    """Simulate a slow service: ?delay=seconds"""
-    sleep(delay)
+async def slow_endpoint(delay: int = 2):
+    """Simulate a slow service that waits for ``delay`` seconds."""
+    await asyncio.sleep(delay)
     return {"status": "done", "delay": delay}
+
+@app.get("/")
+async def root():
+    return {"status": "ok"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 jinja2
 pydantic
 python-multipart
+gunicorn


### PR DESCRIPTION
## Summary
- convert FastAPI endpoints to `async` functions
- use `asyncio.sleep` in the slow endpoint
- document how to run the app for JMeter practice
- add gunicorn to requirements
- rename README file

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile main.py models.py storage.py`


------
https://chatgpt.com/codex/tasks/task_e_687208e7df588333ad1ea66b5471eca5